### PR TITLE
Billboardからステータスを削除する機能の実装

### DIFF
--- a/src/commands/vc.ts
+++ b/src/commands/vc.ts
@@ -32,7 +32,6 @@ const command = new SlashCommandBuilder()
 
 const vcObjectiveMap = new Map();
 
-
 export const updateVcObjectiveMappingAndMessage = async (client: Client, activeGuild: string) => {
   // チャンネルのログを読み、自身の投稿が存在したら削除する
   const outgoingChannelId = serverChannelMap.get(activeGuild);


### PR DESCRIPTION
close #6 

## やったこと
- VCコマンドのサブコマンドとしてcreateとdeleteを追加
  - createは今まで通りの機能であるobjectiveが使用できる
  - deleteは削除機能 `/vc delete`と打つことで現在のVCチャンネルのステータスを削除できる
- subcommandを実装するため、isChatInputCommand()?の判定を追加
  - よく分かってないですこれ StackOverFlowで調べたら出てきて、使ったら治った
  - それまではomitされてたのでそのomitを取り消すことが出来る関数として認識 

## Random
私はこうしたいってやつそのまま実装したので、よーかいさん側の実装の方がいいならそっちにします こっちとどっちがいいか話したい

eslintの回し方わからない 普通にやろうとしたらエラーが出たのでこれも後でやるべきかな?
```
Error: Error while loading rule '@typescript-eslint/dot-notation': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
```